### PR TITLE
feat: add in-app chat with real-time messaging

### DIFF
--- a/src/app/(app)/items/[id]/chat-action.ts
+++ b/src/app/(app)/items/[id]/chat-action.ts
@@ -1,0 +1,46 @@
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+
+export async function startChat(itemId: string, sellerId: string) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { error: "Nicht angemeldet." };
+
+  if (user.id === sellerId) {
+    return { error: "Du kannst dir nicht selbst schreiben." };
+  }
+
+  // Check if conversation already exists
+  const { data: existing } = await supabase
+    .from("conversations")
+    .select("id")
+    .eq("item_id", itemId)
+    .eq("buyer_id", user.id)
+    .maybeSingle();
+
+  if (existing) {
+    redirect(`/messages/${existing.id}`);
+  }
+
+  // Create new conversation
+  const { data: conversation, error } = await supabase
+    .from("conversations")
+    .insert({
+      item_id: itemId,
+      buyer_id: user.id,
+      seller_id: sellerId,
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    return { error: "Chat konnte nicht erstellt werden. Bitte versuche es erneut." };
+  }
+
+  redirect(`/messages/${conversation.id}`);
+}

--- a/src/app/(app)/items/[id]/page.tsx
+++ b/src/app/(app)/items/[id]/page.tsx
@@ -18,6 +18,7 @@ import type { ItemWithSellerDetail } from "@/lib/types/database";
 import type { Reservation } from "@/lib/types/database";
 import { ReserveButton } from "./reserve-button";
 import { CancelReservationButton } from "./cancel-reservation-button";
+import { StartChatButton } from "@/components/start-chat-button";
 
 export default async function ItemDetailPage({
   params,
@@ -243,6 +244,13 @@ export default async function ItemDetailPage({
                 vorbei!
               </p>
             </div>
+          )}
+
+          {!isOwner && user && (
+            <StartChatButton
+              itemId={id}
+              sellerId={typedItem.seller_id}
+            />
           )}
         </div>
       </div>

--- a/src/app/(app)/messages/[id]/layout.tsx
+++ b/src/app/(app)/messages/[id]/layout.tsx
@@ -1,0 +1,13 @@
+export default function ConversationLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // Override the app layout's pb-20 and hide the BottomNav
+  // by rendering children in a full-screen container
+  return (
+    <div className="fixed inset-0 z-50 bg-background">
+      {children}
+    </div>
+  );
+}

--- a/src/app/(app)/messages/[id]/page.tsx
+++ b/src/app/(app)/messages/[id]/page.tsx
@@ -1,0 +1,78 @@
+import { notFound, redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { ChatView } from "@/components/chat-view";
+import type { Conversation, Message } from "@/lib/types/database";
+
+export default async function ConversationPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  // Fetch conversation with item and both profiles
+  const { data: conversation } = await supabase
+    .from("conversations")
+    .select(
+      `
+      *,
+      item:items!item_id (
+        id,
+        title,
+        image_url
+      ),
+      buyer:profiles!buyer_id (
+        id,
+        name,
+        avatar_url
+      ),
+      seller:profiles!seller_id (
+        id,
+        name,
+        avatar_url
+      )
+    `
+    )
+    .eq("id", id)
+    .single();
+
+  if (!conversation) notFound();
+
+  const typedConversation = conversation as unknown as Conversation & {
+    item: { id: string; title: string; image_url: string };
+    buyer: { id: string; name: string; avatar_url: string | null };
+    seller: { id: string; name: string; avatar_url: string | null };
+  };
+
+  // Verify current user is a participant
+  const isBuyer = user.id === typedConversation.buyer_id;
+  const isSeller = user.id === typedConversation.seller_id;
+  if (!isBuyer && !isSeller) redirect("/messages");
+
+  const otherUser = isBuyer
+    ? typedConversation.seller
+    : typedConversation.buyer;
+
+  // Fetch messages
+  const { data: messages } = await supabase
+    .from("messages")
+    .select("*")
+    .eq("conversation_id", id)
+    .order("created_at", { ascending: true });
+
+  return (
+    <ChatView
+      conversationId={id}
+      currentUserId={user.id}
+      initialMessages={(messages as Message[]) || []}
+      item={typedConversation.item}
+      otherUser={otherUser}
+    />
+  );
+}

--- a/src/app/(app)/messages/page.tsx
+++ b/src/app/(app)/messages/page.tsx
@@ -1,0 +1,177 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import Image from "next/image";
+import { MessageCircle } from "lucide-react";
+import { createClient } from "@/lib/supabase/server";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { getStorageUrl, timeAgo } from "@/lib/utils";
+import type { Conversation, Message } from "@/lib/types/database";
+
+type ConversationRow = Conversation & {
+  item: { id: string; title: string; image_url: string };
+  buyer: { id: string; name: string; avatar_url: string | null };
+  seller: { id: string; name: string; avatar_url: string | null };
+};
+
+export default async function MessagesPage() {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/login");
+
+  // Fetch conversations where user is participant
+  const { data: conversations } = await supabase
+    .from("conversations")
+    .select(
+      `
+      *,
+      item:items!item_id (
+        id,
+        title,
+        image_url
+      ),
+      buyer:profiles!buyer_id (
+        id,
+        name,
+        avatar_url
+      ),
+      seller:profiles!seller_id (
+        id,
+        name,
+        avatar_url
+      )
+    `
+    )
+    .or(`buyer_id.eq.${user.id},seller_id.eq.${user.id}`)
+    .order("updated_at", { ascending: false });
+
+  const typedConversations = (conversations || []) as unknown as ConversationRow[];
+
+  // Fetch last message + unread count for each conversation
+  const conversationsWithMeta = await Promise.all(
+    typedConversations.map(async (conv) => {
+      const { data: lastMessages } = await supabase
+        .from("messages")
+        .select("content, created_at, sender_id")
+        .eq("conversation_id", conv.id)
+        .order("created_at", { ascending: false })
+        .limit(1);
+
+      const lastMessage = (lastMessages?.[0] as Pick<
+        Message,
+        "content" | "created_at" | "sender_id"
+      >) || null;
+
+      const { count } = await supabase
+        .from("messages")
+        .select("id", { count: "exact", head: true })
+        .eq("conversation_id", conv.id)
+        .neq("sender_id", user.id)
+        .is("read_at", null);
+
+      const otherUser =
+        user.id === conv.buyer_id ? conv.seller : conv.buyer;
+
+      return { ...conv, lastMessage, unreadCount: count || 0, otherUser };
+    })
+  );
+
+  return (
+    <div className="mx-auto max-w-lg">
+      <div className="px-4 py-4">
+        <h1 className="text-xl font-bold">Nachrichten</h1>
+      </div>
+
+      {conversationsWithMeta.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 px-4 py-16 text-center">
+          <MessageCircle className="h-12 w-12 text-muted-foreground/50" />
+          <p className="text-sm text-muted-foreground">
+            Noch keine Nachrichten. Stöbere durch die Artikel und schreib den
+            Verkäufer an!
+          </p>
+        </div>
+      ) : (
+        <div className="divide-y">
+          {conversationsWithMeta.map((conv) => {
+            const itemImageUrl = getStorageUrl("items", conv.item.image_url);
+            const avatarUrl = conv.otherUser.avatar_url
+              ? getStorageUrl("avatars", conv.otherUser.avatar_url)
+              : null;
+            const initial =
+              conv.otherUser.name?.charAt(0).toUpperCase() || "?";
+
+            return (
+              <Link
+                key={conv.id}
+                href={`/messages/${conv.id}`}
+                className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-accent/50"
+              >
+                {/* Item thumbnail */}
+                <div className="relative h-12 w-12 flex-shrink-0 overflow-hidden rounded-lg">
+                  <Image
+                    src={itemImageUrl}
+                    alt={conv.item.title}
+                    fill
+                    className="object-cover"
+                    sizes="48px"
+                  />
+                </div>
+
+                {/* Content */}
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-1.5 min-w-0">
+                      <Avatar className="h-5 w-5 flex-shrink-0">
+                        {avatarUrl && (
+                          <AvatarImage
+                            src={avatarUrl}
+                            alt={conv.otherUser.name}
+                          />
+                        )}
+                        <AvatarFallback className="text-[8px]">
+                          {initial}
+                        </AvatarFallback>
+                      </Avatar>
+                      <span className="truncate text-sm font-medium">
+                        {conv.otherUser.name}
+                      </span>
+                    </div>
+                    {conv.lastMessage && (
+                      <span className="flex-shrink-0 text-[10px] text-muted-foreground">
+                        {timeAgo(conv.lastMessage.created_at)}
+                      </span>
+                    )}
+                  </div>
+                  <p className="truncate text-xs text-muted-foreground mt-0.5">
+                    {conv.item.title}
+                  </p>
+                  {conv.lastMessage && (
+                    <p
+                      className={`mt-0.5 truncate text-xs ${
+                        conv.unreadCount > 0
+                          ? "font-medium text-foreground"
+                          : "text-muted-foreground"
+                      }`}
+                    >
+                      {conv.lastMessage.sender_id === user.id ? "Du: " : ""}
+                      {conv.lastMessage.content}
+                    </p>
+                  )}
+                </div>
+
+                {/* Unread badge */}
+                {conv.unreadCount > 0 && (
+                  <div className="flex h-5 min-w-5 flex-shrink-0 items-center justify-center rounded-full bg-primary px-1.5 text-[10px] font-bold text-primary-foreground">
+                    {conv.unreadCount}
+                  </div>
+                )}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/bottom-nav.tsx
+++ b/src/components/bottom-nav.tsx
@@ -2,13 +2,15 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Home, Users, PlusCircle, User } from "lucide-react";
+import { Home, Users, PlusCircle, MessageCircle, User } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { UnreadBadge } from "@/components/unread-badge";
 
 const tabs = [
   { href: "/", label: "Home", icon: Home },
   { href: "/profiles", label: "Stöbern", icon: Users },
   { href: "/items/new", label: "Einstellen", icon: PlusCircle },
+  { href: "/messages", label: "Nachrichten", icon: MessageCircle },
   { href: "/profile", label: "Profil", icon: User },
 ] as const;
 
@@ -35,9 +37,12 @@ export function BottomNav() {
                   : "text-muted-foreground hover:text-foreground"
               )}
             >
-              <tab.icon
-                className={cn("h-5 w-5", isActive && "stroke-[2.5]")}
-              />
+              <span className="relative">
+                <tab.icon
+                  className={cn("h-5 w-5", isActive && "stroke-[2.5]")}
+                />
+                {tab.href === "/messages" && <UnreadBadge />}
+              </span>
               <span className={cn(isActive && "font-medium")}>{tab.label}</span>
             </Link>
           );

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowLeft, Send } from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { getStorageUrl, timeAgo } from "@/lib/utils";
+import type { Message } from "@/lib/types/database";
+
+type ChatItem = {
+  id: string;
+  title: string;
+  image_url: string;
+};
+
+type ChatUser = {
+  id: string;
+  name: string;
+  avatar_url: string | null;
+};
+
+export function ChatView({
+  conversationId,
+  currentUserId,
+  initialMessages,
+  item,
+  otherUser,
+}: {
+  conversationId: string;
+  currentUserId: string;
+  initialMessages: Message[];
+  item: ChatItem;
+  otherUser: ChatUser;
+}) {
+  const [messages, setMessages] = useState<Message[]>(initialMessages);
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const supabase = createClient();
+
+  // Auto-scroll to bottom
+  function scrollToBottom() {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+    }
+  }
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages]);
+
+  // Mark unread messages as read
+  useEffect(() => {
+    const unreadIds = messages
+      .filter((m) => m.sender_id !== currentUserId && !m.read_at)
+      .map((m) => m.id);
+
+    if (unreadIds.length === 0) return;
+
+    supabase
+      .from("messages")
+      .update({ read_at: new Date().toISOString() })
+      .in("id", unreadIds)
+      .then(() => {
+        setMessages((prev) =>
+          prev.map((m) =>
+            unreadIds.includes(m.id) ? { ...m, read_at: new Date().toISOString() } : m
+          )
+        );
+      });
+  }, [messages, currentUserId, supabase]);
+
+  // Real-time subscription
+  useEffect(() => {
+    const channel = supabase
+      .channel(`messages:${conversationId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "messages",
+          filter: `conversation_id=eq.${conversationId}`,
+        },
+        (payload) => {
+          const newMsg = payload.new as Message;
+          setMessages((prev) => {
+            // Avoid duplicates (optimistic update already added it)
+            if (prev.some((m) => m.id === newMsg.id)) return prev;
+            return [...prev, newMsg];
+          });
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [conversationId, supabase]);
+
+  async function handleSend() {
+    const content = input.trim();
+    if (!content || sending) return;
+
+    setSending(true);
+    setInput("");
+
+    // Optimistic message
+    const optimisticMsg: Message = {
+      id: crypto.randomUUID(),
+      conversation_id: conversationId,
+      sender_id: currentUserId,
+      content,
+      read_at: null,
+      created_at: new Date().toISOString(),
+    };
+    setMessages((prev) => [...prev, optimisticMsg]);
+
+    const { error } = await supabase.from("messages").insert({
+      conversation_id: conversationId,
+      sender_id: currentUserId,
+      content,
+    });
+
+    if (error) {
+      // Remove optimistic message on failure
+      setMessages((prev) => prev.filter((m) => m.id !== optimisticMsg.id));
+      setInput(content);
+    }
+
+    setSending(false);
+    inputRef.current?.focus();
+  }
+
+  const itemImageUrl = getStorageUrl("items", item.image_url);
+  const otherAvatarUrl = otherUser.avatar_url
+    ? getStorageUrl("avatars", otherUser.avatar_url)
+    : null;
+  const otherInitial = otherUser.name?.charAt(0).toUpperCase() || "?";
+
+  return (
+    <div className="flex h-[100dvh] flex-col">
+      {/* Header */}
+      <div className="flex items-center gap-3 border-b bg-background px-3 py-2">
+        <Link
+          href="/messages"
+          className="flex-shrink-0 rounded-full p-1 hover:bg-accent"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </Link>
+        <Link
+          href={`/items/${item.id}`}
+          className="flex min-w-0 flex-1 items-center gap-3"
+        >
+          <div className="relative h-10 w-10 flex-shrink-0 overflow-hidden rounded-lg">
+            <Image
+              src={itemImageUrl}
+              alt={item.title}
+              fill
+              className="object-cover"
+              sizes="40px"
+            />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium">{item.title}</p>
+            <div className="flex items-center gap-1.5">
+              <Avatar className="h-4 w-4">
+                {otherAvatarUrl && (
+                  <AvatarImage src={otherAvatarUrl} alt={otherUser.name} />
+                )}
+                <AvatarFallback className="text-[8px]">
+                  {otherInitial}
+                </AvatarFallback>
+              </Avatar>
+              <p className="truncate text-xs text-muted-foreground">
+                {otherUser.name}
+              </p>
+            </div>
+          </div>
+        </Link>
+      </div>
+
+      {/* Messages */}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-4">
+        <div className="mx-auto flex max-w-lg flex-col gap-2">
+          {messages.length === 0 && (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              Schreib die erste Nachricht!
+            </p>
+          )}
+          {messages.map((msg) => {
+            const isMine = msg.sender_id === currentUserId;
+            return (
+              <div
+                key={msg.id}
+                className={cn(
+                  "flex flex-col",
+                  isMine ? "items-end" : "items-start"
+                )}
+              >
+                <div
+                  className={cn(
+                    "max-w-[80%] rounded-2xl px-3.5 py-2 text-sm",
+                    isMine
+                      ? "rounded-br-md bg-primary text-primary-foreground"
+                      : "rounded-bl-md bg-muted"
+                  )}
+                >
+                  <p className="whitespace-pre-wrap break-words">{msg.content}</p>
+                </div>
+                <span className="mt-0.5 px-1 text-[10px] text-muted-foreground">
+                  {timeAgo(msg.created_at)}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Input bar */}
+      <div className="border-t bg-background px-3 py-2">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSend();
+          }}
+          className="mx-auto flex max-w-lg items-end gap-2"
+        >
+          <textarea
+            ref={inputRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                handleSend();
+              }
+            }}
+            placeholder="Nachricht schreiben…"
+            rows={1}
+            maxLength={2000}
+            className="flex-1 resize-none rounded-xl border bg-muted/50 px-3.5 py-2.5 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+          <Button
+            type="submit"
+            size="icon"
+            disabled={!input.trim() || sending}
+            className="h-10 w-10 flex-shrink-0 rounded-full"
+          >
+            <Send className="h-4 w-4" />
+          </Button>
+        </form>
+        {/* Safe area padding for iOS */}
+        <div className="h-[env(safe-area-inset-bottom)]" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/start-chat-button.tsx
+++ b/src/components/start-chat-button.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useTransition } from "react";
+import { MessageCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { toast } from "sonner";
+import { startChat } from "@/app/(app)/items/[id]/chat-action";
+
+export function StartChatButton({
+  itemId,
+  sellerId,
+}: {
+  itemId: string;
+  sellerId: string;
+}) {
+  const [isPending, startTransition] = useTransition();
+
+  function handleClick() {
+    startTransition(async () => {
+      const result = await startChat(itemId, sellerId);
+      if (result?.error) {
+        toast.error(result.error);
+      }
+    });
+  }
+
+  return (
+    <Button
+      onClick={handleClick}
+      disabled={isPending}
+      variant="outline"
+      className="w-full"
+      size="lg"
+    >
+      <MessageCircle className="mr-2 h-4 w-4" />
+      {isPending ? "Wird geöffnet…" : "Nachricht schreiben"}
+    </Button>
+  );
+}

--- a/src/components/unread-badge.tsx
+++ b/src/components/unread-badge.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+
+export function UnreadBadge() {
+  const [count, setCount] = useState(0);
+  const [userId, setUserId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const supabase = createClient();
+
+    async function init() {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return;
+
+      setUserId(user.id);
+
+      // Fetch initial unread count
+      const { data: conversations } = await supabase
+        .from("conversations")
+        .select("id")
+        .or(`buyer_id.eq.${user.id},seller_id.eq.${user.id}`);
+
+      if (!conversations || conversations.length === 0) {
+        setCount(0);
+        return;
+      }
+
+      const convIds = conversations.map((c) => c.id);
+
+      const { count: unread } = await supabase
+        .from("messages")
+        .select("id", { count: "exact", head: true })
+        .in("conversation_id", convIds)
+        .neq("sender_id", user.id)
+        .is("read_at", null);
+
+      setCount(unread || 0);
+    }
+
+    init();
+  }, []);
+
+  // Real-time subscription (only after we know the userId)
+  useEffect(() => {
+    if (!userId) return;
+
+    const supabase = createClient();
+    const channel = supabase
+      .channel("unread-badge")
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "messages",
+        },
+        (payload) => {
+          const newMsg = payload.new as { sender_id: string };
+          if (newMsg.sender_id !== userId) {
+            setCount((prev) => prev + 1);
+          }
+        }
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "messages",
+        },
+        (payload) => {
+          const updated = payload.new as {
+            read_at: string | null;
+            sender_id: string;
+          };
+          const old = payload.old as { read_at: string | null };
+          if (updated.read_at && !old.read_at && updated.sender_id !== userId) {
+            setCount((prev) => Math.max(0, prev - 1));
+          }
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [userId]);
+
+  if (count === 0) return null;
+
+  return (
+    <span className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-destructive px-1 text-[9px] font-bold text-destructive-foreground">
+      {count > 99 ? "99+" : count}
+    </span>
+  );
+}

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -79,3 +79,34 @@ export type ReservationWithItem = Reservation & {
     seller: Pick<Profile, "id" | "name" | "phone" | "avatar_url">;
   };
 };
+
+// Chat types
+
+export type Conversation = {
+  id: string;
+  item_id: string;
+  buyer_id: string;
+  seller_id: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type Message = {
+  id: string;
+  conversation_id: string;
+  sender_id: string;
+  content: string;
+  read_at: string | null;
+  created_at: string;
+};
+
+export type ConversationWithDetails = Conversation & {
+  item: Pick<Item, "id" | "title" | "image_url">;
+  other_user: Pick<Profile, "id" | "name" | "avatar_url">;
+  last_message: Pick<Message, "content" | "created_at" | "sender_id"> | null;
+  unread_count: number;
+};
+
+export type MessageWithSender = Message & {
+  sender: Pick<Profile, "id" | "name" | "avatar_url">;
+};


### PR DESCRIPTION
## Summary
- Add real-time in-app messaging system tied to items (conversations + messages tables with RLS, Supabase Realtime)
- New "Nachrichten" tab in bottom navigation with live unread badge
- Chat UI with optimistic sends, auto-scroll, mark-as-read, and item context header
- "Nachricht schreiben" button on item detail pages for non-owners

## Test plan
- [ ] Open item detail as non-owner → "Nachricht schreiben" button visible
- [ ] Click button → conversation created, navigated to chat view
- [ ] Send message → appears instantly (optimistic UI), persists on reload
- [ ] Open same chat as other user → message appears in real-time
- [ ] Unread badge shows on Nachrichten tab for recipient
- [ ] Opening conversation marks messages as read, badge clears
- [ ] Conversation list shows all chats sorted by most recent, with last message preview
- [ ] Item thumbnail in chat header links back to item detail
- [ ] Deleting an item cascades to delete its conversations
- [ ] All UI copy is in German
- [ ] `pnpm build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)