### PR TITLE
feat: email notifications + post-signup login redirect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzd
 
 # Server-only (used for account deletion)
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
+
+# Resend (email notifications — set as Supabase Edge Function secret)
+# Get your API key at https://resend.com/api-keys
+RESEND_API_KEY=re_xxxxxxxxx

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,8 +20,10 @@ Browser (PWA)
           ├── Auth (email/password, email verification)
           ├── Postgres (profiles, items, reservations, children, conversations, messages)
           ├── Realtime (postgres_changes on messages table)
+          ├── Edge Functions (send-notification → Resend email API)
           ├── Storage (avatars, item photos)
           ├── RLS (row-level security on all tables)
+          ├── pg_net (async HTTP from triggers → Edge Functions)
           └── pg_cron (reservation expiry every 15 min)
 ```
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 ## 2026-02-09
 
 ### Added
+- [notifications] Email notifications via Resend + Supabase Edge Function (`send-notification`)
+- [notifications] New reservation → seller receives email with buyer name, item title, and link to item
+- [notifications] New chat message → recipient receives email with sender name, message preview, and link to conversation
+- [db] `pg_net` extension enabled for async HTTP from database triggers
+- [db] `notify_on_reservation()` trigger function — sends webhook to Edge Function on new reservation
+- [db] `notify_on_message()` trigger function — sends webhook to Edge Function on new message
 - [chat] In-app messaging system — conversations tied to items, real-time message delivery via Supabase Postgres Changes
 - [chat] Conversation list page (`/messages`) — item thumbnails, other user avatar, last message preview, unread counts
 - [chat] Conversation detail page (`/messages/[id]`) — full-screen chat with message bubbles, optimistic sends, auto-scroll

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -196,6 +196,16 @@ Both buckets are publicly readable (images need to display without auth). Upload
 - **Event**: After INSERT on `messages`
 - **Action**: Updates the parent conversation's `updated_at` to now(), so conversation list sorts by latest message
 
+### on_reservation_send_notification
+
+- **Event**: After INSERT on `reservations`
+- **Action**: Calls Edge Function `send-notification` via `pg_net` HTTP POST — sends email to seller with buyer name and item title
+
+### on_message_send_notification
+
+- **Event**: After INSERT on `messages`
+- **Action**: Calls Edge Function `send-notification` via `pg_net` HTTP POST — sends email to other conversation participant with sender name and message preview
+
 ### expire_reservations (Cron)
 
 - **Mechanism**: Supabase `pg_cron` extension (available on free tier)

--- a/docs/PRODUCT_STATUS.md
+++ b/docs/PRODUCT_STATUS.md
@@ -63,7 +63,7 @@
 - [x] In-app chat (per item, real-time via Supabase Realtime)
 - [ ] Item browsing page with search
 - [ ] Filter by type, monetization, child age
-- [ ] Email notifications for reservations
+- [x] Email notifications (reservations + new messages via Resend)
 
 ---
 

--- a/docs/TECH.md
+++ b/docs/TECH.md
@@ -27,6 +27,8 @@ See `.env.example` in the project root.
 |----------|-------------|--------|
 | `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL | Yes (client-side) |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anon/public key | Yes (client-side, protected by RLS) |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key (server-only, for account deletion) | No |
+| `RESEND_API_KEY` | Resend API key (set as Supabase Edge Function secret) | No |
 
 ## Authentication
 
@@ -45,6 +47,17 @@ Handled entirely by Supabase Auth:
 - Bucket paths:
   - Avatars: `avatars/{user_id}/avatar.{ext}`
   - Items: `items/{user_id}/{item_id}.{ext}`
+
+## Email Notifications
+
+- **Provider**: Resend (free tier: 100 emails/day)
+- **Trigger**: Database webhook via `pg_net` triggers on `messages` and `reservations` tables
+- **Edge Function**: `send-notification` — deployed on Supabase, receives webhook payload, queries recipient details, sends email via Resend API
+- **Events**:
+  - New reservation → seller receives email with buyer name and item title
+  - New message → other conversation participant receives email with sender name and message preview
+- **Sender**: `Kinderkreisel <onboarding@resend.dev>` (Resend test domain — upgrade to custom domain later)
+- **Secret**: `RESEND_API_KEY` stored as Supabase Edge Function secret
 
 ## Reservation Expiry
 

--- a/src/app/(auth)/auth/confirm/route.ts
+++ b/src/app/(auth)/auth/confirm/route.ts
@@ -19,6 +19,11 @@ export async function GET(request: NextRequest) {
     });
 
     if (!error) {
+      // For signup confirmation, sign out so user lands on login page
+      // (middleware would otherwise redirect authenticated users away from /login)
+      if (type === "signup" && next === "/login") {
+        await supabase.auth.signOut();
+      }
       redirect(next);
     } else {
       redirect(`/auth/error?error=${encodeURIComponent(error.message)}`);

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useEffect } from "react";
+import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
 import { createClient } from "@/lib/supabase/client";
@@ -26,6 +27,13 @@ export function LoginForm({
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (searchParams.get("verified") === "1") {
+      toast.success("E-Mail bestätigt! Du kannst dich jetzt einloggen.");
+    }
+  }, [searchParams]);
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/components/sign-up-form.tsx
+++ b/src/components/sign-up-form.tsx
@@ -65,7 +65,7 @@ export function SignUpForm({
         email: formData.email,
         password: formData.password,
         options: {
-          emailRedirectTo: `${window.location.origin}/auth/confirm`,
+          emailRedirectTo: `${window.location.origin}/auth/confirm?next=${encodeURIComponent("/login?verified=1")}`,
           data: {
             name: formData.name,
             surname: formData.surname,


### PR DESCRIPTION
## Summary
- **Email notifications** via Resend + Supabase Edge Function (`send-notification`) — sellers get notified on new reservations, chat participants get notified on new messages
- **Database triggers** using `pg_net` to async-call the Edge Function on INSERT to `messages` and `reservations`
- **Post-signup redirect** — clicking "Confirm your mail" now redirects to the login page with a success toast instead of auto-logging in

## Test plan
- [ ] Set `RESEND_API_KEY` as Supabase Edge Function secret
- [ ] Reserve an item as user A → verify seller receives reservation email
- [ ] Send a chat message → verify recipient receives message notification email
- [ ] Check Edge Function logs for successful execution
- [ ] Sign up with a new email → confirm email → verify redirect to login page with toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)