### PR TITLE
feat: batch message digest emails (6-hourly)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 ## 2026-02-09
 
 ### Added
+- [notifications] Batch message digest emails — replaces per-message instant emails with a 6-hourly digest
+- [notifications] Edge Function `send-message-digest` — queries unread messages, groups by conversation, sends digest via Resend
+- [db] `last_message_email_at` column on `profiles` (default `now()`) — tracks last digest send per user
+- [db] `get_unread_messages_for_digest` SQL function (RPC) — returns unread messages for a user since a given timestamp
+- [db] `pg_cron` job `send-message-digest` — runs every 6 hours, calls Edge Function via `pg_net`
+- [db] Vault secrets `project_url` and `anon_key` — used by cron job to invoke Edge Functions securely
+
+### Changed
+- [notifications] Edge Function `send-notification` v4 — removed `handleMessage()`, now only handles reservation notifications
+- [notifications] Message emails are now batched (6h digest) instead of instant; reservation emails remain instant
+
+### Removed
+- [db] Trigger `on_message_send_notification` and function `notify_on_message()` — replaced by cron-based digest
+
+---
+
+## 2026-02-09 (earlier)
+
+### Added
 - [notifications] Email notifications via Resend + Supabase Edge Function (`send-notification`)
 - [notifications] New reservation → seller receives email with buyer name, item title, and link to item
 - [notifications] New chat message → recipient receives email with sender name, message preview, and link to conversation

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import * as React from "react"
+import { Switch as SwitchPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block rounded-full ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -7,6 +7,8 @@ export type Profile = {
   phone: string;
   avatar_url: string | null;
   phone_consent: boolean;
+  email_notifications: boolean;
+  last_message_email_at: string;
   created_at: string;
   updated_at: string;
 };


### PR DESCRIPTION
## Summary
- **Replaces per-message instant emails** with a **6-hourly batch digest** for chat messages
- **Reservation notifications remain instant** (time-sensitive, 48h expiry)
- New Edge Function `send-message-digest` queries unread messages, groups by conversation, sends one digest email per user via Resend
- `pg_cron` job runs every 6 hours, using Vault-stored secrets for secure invocation

## Changes

### Supabase (already deployed)
- Migration: `last_message_email_at` column on `profiles` (default `now()`)
- Migration: Dropped trigger `on_message_send_notification` + function `notify_on_message()`
- Migration: Created `get_unread_messages_for_digest()` RPC function
- Edge Function `send-notification` v4 — reservations only
- Edge Function `send-message-digest` v1 — batch digest logic
- pg_cron job `send-message-digest` — every 6 hours
- Vault secrets: `project_url`, `anon_key`

### Code
- `src/lib/types/database.ts` — added `email_notifications` + `last_message_email_at` to Profile type
- `src/components/ui/switch.tsx` — shadcn Switch component

### Docs
- `DATABASE.md` — new columns, removed message trigger, added digest cron + RPC docs
- `TECH.md` — restructured email notifications section (instant vs batched)
- `CHANGELOG.md` — logged all changes

## Test plan
- [ ] Send a chat message → no instant email fires
- [ ] Manually invoke `send-message-digest` Edge Function → digest email arrives with unread messages grouped by conversation
- [ ] Read messages in-app → next digest skips them
- [ ] User with `email_notifications = false` → no digest email
- [ ] Create a reservation → instant email still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)