### PR TITLE
Rebrand to findln + message digest emails + theme update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Kinderkreisel
+# findln
 
 Local community marketplace for giving away and finding secondhand children's items (clothing, sports equipment) in zip code 83623, Germany.
 
@@ -36,7 +36,7 @@ All project docs live in `docs/`. Read these before making changes:
 ## Project Structure
 
 ```
-kinderkreisel/
+findln/
 ├── .claude/
 │   └── commands/
 │       └── update-docs-and-commit.md

--- a/Kinderkreisel.md
+++ b/Kinderkreisel.md
@@ -1,4 +1,4 @@
-# Kinderkreisel
+# findln
 
 A local community marketplace for giving away children's items in zip code 83623, Germany.
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# kinderkreisel
+# findln

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Kinderkreisel is a mobile-first web app built with Next.js 15 (App Router) and Supabase as the backend.
+findln is a mobile-first web app built with Next.js 15 (App Router) and Supabase as the backend.
 
 ## High-Level Architecture
 

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -1,4 +1,4 @@
-# Kinderkreisel — Database Design
+# findln — Database Design
 
 ## Overview
 

--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -1,4 +1,4 @@
-# Kinderkreisel — MVP Specification
+# findln — MVP Specification
 
 The MVP delivers a functional marketplace where users can sign up, post items, browse, and reserve items for pickup.
 

--- a/docs/MVP_TASKS.md
+++ b/docs/MVP_TASKS.md
@@ -1,6 +1,6 @@
 # MVP Build — Granular Task List
 
-This is the step-by-step build plan for the Kinderkreisel MVP. Each task is small enough to pick up independently. Check off tasks as they are completed.
+This is the step-by-step build plan for the findln MVP. Each task is small enough to pick up independently. Check off tasks as they are completed.
 
 ---
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,4 +1,4 @@
-# Kinderkreisel — Product Requirements
+# findln — Product Requirements
 
 ## Vision
 

--- a/docs/SEARCH_FEATURE.md
+++ b/docs/SEARCH_FEATURE.md
@@ -1,0 +1,74 @@
+# findln — Search & Filter Feature (Option 2a)
+
+Adds text search and pricing filter to the home page using server-side Supabase `.ilike()` queries with URL search params. No database migrations required.
+
+## Overview
+
+| Aspect | Detail |
+|--------|--------|
+| Approach | Server-side filtering via Supabase `.ilike()` + `.eq()` |
+| Location | Existing home page (`/`) |
+| State management | URL search params (`?q=...&pricing=...`) |
+| DB changes | None |
+| New dependencies | None |
+
+## Tasks
+
+### 1. Create `SearchFilter` client component
+
+- **File**: `src/components/search-filter.tsx`
+- **Type**: Client component (`"use client"`)
+- **Contains**:
+  - Text input for search (placeholder: `"Artikel suchen..."`)
+  - Select dropdown for pricing type filter with options:
+    - `""` — Alle (all / default)
+    - `"free"` — Zu verschenken
+    - `"lending"` — Zum Leihen
+    - `"other"` — Sonstiges
+- **Behavior**:
+  - On form submit (Enter key or button), updates URL search params `?q=<text>&pricing=<type>`
+  - Uses `useRouter` + `useSearchParams` from `next/navigation`
+  - Preserves existing param values on load (controlled inputs from URL)
+  - Debounce is NOT needed — search triggers on explicit submit (Enter / button)
+  - Clearing the input and submitting removes the `q` param
+  - Selecting "Alle" removes the `pricing` param
+- **UI**: Uses existing shadcn `Input`, `Select`, and `Button` components
+- **Layout**: Search input and filter in a single responsive row below the page header
+
+### 2. Update home page to read search params and filter query
+
+- **File**: `src/app/(app)/page.tsx`
+- **Changes**:
+  - Accept `searchParams` prop (Next.js server component convention)
+  - Read `q` and `pricing` from search params
+  - Build Supabase query conditionally:
+    - If `q` is present: add `.or('title.ilike.%${q}%,description.ilike.%${q}%')`
+    - If `pricing` is present: add `.eq('pricing_type', pricing)`
+  - Render `<SearchFilter />` component between header and item grid
+  - Show "Keine Ergebnisse" empty state when search/filter returns 0 results (distinct from "no items exist" state)
+
+### 3. Update empty state messaging
+
+- No items at all (no search active): `"Noch keine Artikel vorhanden."` (existing)
+- No results for search/filter: `"Keine Artikel gefunden. Versuch es mit einem anderen Suchbegriff."` (new)
+
+## Out of Scope
+
+- Full-text search (`tsvector`/`tsquery`) — future upgrade
+- Category / item type filter — requires DB schema change
+- Child age filter — requires DB schema change
+- Dedicated `/items` browse page — future Option 3
+- Debounced live search — not needed for explicit submit UX
+- Search result ranking / relevance scoring
+
+## Acceptance Criteria
+
+- [ ] User can type a search term and press Enter to filter items by title or description
+- [ ] User can select a pricing type to filter items
+- [ ] Search and filter can be combined
+- [ ] URL reflects current search state (shareable, back-button works)
+- [ ] Clearing search/filter shows all items again
+- [ ] Empty search results show a helpful German message
+- [ ] No database migration needed
+- [ ] All UI copy is in German
+- [ ] Uses existing shadcn/ui components only

--- a/docs/TECH.md
+++ b/docs/TECH.md
@@ -1,4 +1,4 @@
-# Kinderkreisel — Technical Requirements
+# findln — Technical Requirements
 
 ## Stack
 
@@ -51,7 +51,7 @@ Handled entirely by Supabase Auth:
 ## Email Notifications
 
 - **Provider**: Resend (free tier: 100 emails/day)
-- **Sender**: `Kinderkreisel <onboarding@resend.dev>` (Resend test domain — upgrade to custom domain later)
+- **Sender**: `findln <onboarding@resend.dev>` (Resend test domain — upgrade to custom domain later)
 - **Secret**: `RESEND_API_KEY` stored as Supabase Edge Function secret
 - **Opt-out**: Users can disable via `email_notifications` toggle on profile page
 

--- a/docs/V1.md
+++ b/docs/V1.md
@@ -1,4 +1,4 @@
-# Kinderkreisel — V1 Specification
+# findln — V1 Specification
 
 V1 builds on the MVP with social login, in-app messaging, improved item discovery, and email notifications.
 

--- a/docs/V2.md
+++ b/docs/V2.md
@@ -1,4 +1,4 @@
-# Kinderkreisel — V2 Specification
+# findln — V2 Specification
 
 V2 introduces AI-powered features, better categorization, and seller guidance.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kinderkreisel",
+  "name": "findln",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -51,7 +51,7 @@ export default async function HomePage({
     <div className="px-4 py-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Kinderkreisel</h1>
+          <h1 className="text-2xl font-bold tracking-tight font-[family-name:var(--font-borel)]">findln</h1>
           <p className="mt-1 text-sm text-muted-foreground">
             Secondhand Kinderartikel in deiner Nachbarschaft.
           </p>

--- a/src/app/(app)/privacy/page.tsx
+++ b/src/app/(app)/privacy/page.tsx
@@ -21,7 +21,7 @@ export default function PrivacyPage() {
           <h2 className="text-base font-semibold">1. Verantwortlicher</h2>
           <p className="text-muted-foreground">
             Verantwortlich für die Datenverarbeitung auf dieser Plattform ist der
-            Betreiber von Kinderkreisel. Kontaktdaten findest du im{" "}
+            Betreiber von findln. Kontaktdaten findest du im{" "}
             <Link href="/impressum" className="underline">
               Impressum
             </Link>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Geist } from "next/font/google";
+import { Geist, Borel } from "next/font/google";
 import { Toaster } from "@/components/ui/sonner";
 import "./globals.css";
 
@@ -8,8 +8,15 @@ const geistSans = Geist({
   subsets: ["latin"],
 });
 
+const borel = Borel({
+  weight: "400",
+  variable: "--font-borel",
+  subsets: ["latin"],
+  display: "swap",
+});
+
 export const metadata: Metadata = {
-  title: "Kinderkreisel",
+  title: "findln",
   description:
     "Secondhand Kinderartikel in deiner Nachbarschaft — verschenken, verleihen, weitergeben.",
 };
@@ -29,7 +36,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="de">
-      <body className={`${geistSans.variable} font-sans antialiased`}>
+      <body className={`${geistSans.variable} ${borel.variable} font-sans antialiased`}>
         {children}
         <Toaster richColors position="top-center" />
       </body>

--- a/src/components/sign-up-form.tsx
+++ b/src/components/sign-up-form.tsx
@@ -101,7 +101,7 @@ export function SignUpForm({
         <CardHeader>
           <CardTitle className="text-2xl">Konto erstellen</CardTitle>
           <CardDescription>
-            Willkommen beim Kinderkreisel! Registrier dich und leg los.
+            Willkommen bei findln! Registrier dich und leg los.
           </CardDescription>
         </CardHeader>
         <CardContent>


### PR DESCRIPTION
## Summary
- **Rebrand**: Rename app from "Kinderkreisel" to **findln** across UI, emails, config, and docs. Add Borel Google Font for brand name display.
- **Message digest emails**: Replace per-message notification emails with a 6-hourly batch digest via `send-message-digest` Edge Function.
- **Theme update**: Update color palette to warm coral/red tones.

## Test plan
- [ ] `pnpm build` passes with no errors
- [ ] Homepage shows "findln" in Borel cursive font
- [ ] Browser tab title says "findln"
- [ ] Sign-up page shows "Willkommen bei findln!"
- [ ] Privacy page shows "Betreiber von findln"
- [ ] Invoke `send-notification` Edge Function — email shows "findln" branding
- [ ] Invoke `send-message-digest` Edge Function — email shows "findln" branding

🤖 Generated with [Claude Code](https://claude.com/claude-code)