### PR TITLE
Add email notification opt-out toggle

### DIFF
--- a/src/app/(app)/profile/profile-edit-toggle.tsx
+++ b/src/app/(app)/profile/profile-edit-toggle.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Pencil } from "lucide-react";
+import { Bell, BellOff, Pencil } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ProfileForm } from "@/components/profile-form";
 import type { Profile } from "@/lib/types/database";
@@ -23,6 +23,13 @@ export function ProfileEditToggle({ profile }: { profile: Profile }) {
         </p>
         <p className="text-sm text-muted-foreground">{profile.residency}</p>
         <p className="text-sm text-muted-foreground">{profile.phone}</p>
+        <p className="text-sm text-muted-foreground flex items-center gap-1.5">
+          {profile.email_notifications ? (
+            <><Bell className="h-3.5 w-3.5" /> E-Mail-Benachrichtigungen: An</>
+          ) : (
+            <><BellOff className="h-3.5 w-3.5" /> E-Mail-Benachrichtigungen: Aus</>
+          )}
+        </p>
       </div>
       <Button
         variant="outline"

--- a/src/components/profile-form.tsx
+++ b/src/components/profile-form.tsx
@@ -6,6 +6,7 @@ import { createClient } from "@/lib/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { toast } from "sonner";
 import type { Profile } from "@/lib/types/database";
 
@@ -22,6 +23,7 @@ export function ProfileForm({
   const [surname, setSurname] = useState(profile.surname);
   const [residency, setResidency] = useState(profile.residency);
   const [phone, setPhone] = useState(profile.phone);
+  const [emailNotifications, setEmailNotifications] = useState(profile.email_notifications);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -40,6 +42,7 @@ export function ProfileForm({
           surname: surname.trim(),
           residency: residency.trim(),
           phone: phone.trim(),
+          email_notifications: emailNotifications,
         })
         .eq("id", profile.id);
 
@@ -90,6 +93,20 @@ export function ProfileForm({
           value={phone}
           onChange={(e) => setPhone(e.target.value)}
           type="tel"
+        />
+      </div>
+
+      <div className="flex items-center justify-between rounded-lg border p-4">
+        <div className="space-y-0.5">
+          <Label htmlFor="email-notifications">E-Mail-Benachrichtigungen</Label>
+          <p className="text-sm text-muted-foreground">
+            Erhalte E-Mails bei neuen Nachrichten und Reservierungen
+          </p>
+        </div>
+        <Switch
+          id="email-notifications"
+          checked={emailNotifications}
+          onCheckedChange={setEmailNotifications}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- Add Switch toggle on profile edit form for enabling/disabling email notifications
- Show bell icon with An/Aus status in profile view mode
- Saves `email_notifications` preference to the `profiles` table (already checked by Edge Functions before sending)

## Context
This UI was developed earlier but got lost in a stash during the theme/rebrand branch merges. The database column and Edge Function logic already exist — this PR adds the missing frontend toggle.

## Test plan
- [ ] Profile page shows notification status with bell icon
- [ ] Editing profile shows Switch toggle for "E-Mail-Benachrichtigungen"
- [ ] Toggling and saving updates the `email_notifications` column in DB
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)