### PR TITLE
feat: expanded categories + chip-based filters

### DIFF
--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -67,6 +67,9 @@ Created automatically via a database trigger when a new user signs up in `auth.u
 | description | text | no | — | |
 | pricing_type | text | no | 'free' | One of: 'free', 'lending', 'other' |
 | pricing_detail | text | yes | null | Free text, only used when pricing_type = 'other' |
+| category | text | no | 'other' | One of: 'clothing', 'shoes', 'toys', 'outdoor_sports', 'other' |
+| size | text | yes | null | Clothing size (50–176), only when category = 'clothing' |
+| shoe_size | text | yes | null | EU shoe size (16–40), only when category = 'shoes' |
 | image_url | text | no | — | Path in Supabase Storage |
 | status | text | no | 'available' | One of: 'available', 'reserved' |
 | created_at | timestamptz | no | now() | |
@@ -229,6 +232,7 @@ Both buckets are publicly readable (images need to display without auth). Upload
 | items | seller_id | btree | Fast lookup of items by seller |
 | items | created_at | btree desc | Home feed sort order |
 | items | status | btree | Filter available items |
+| items | category | btree | Filter by category |
 | reservations | item_id, status | btree (partial: WHERE status = 'active') | Fast active reservation lookup |
 | reservations | buyer_id | btree | User's reservations |
 | profiles | id | btree (PK) | Already indexed |

--- a/src/app/(app)/items/[id]/edit/page.tsx
+++ b/src/app/(app)/items/[id]/edit/page.tsx
@@ -45,6 +45,7 @@ export default async function EditItemPage({
             pricing_detail: item.pricing_detail,
             category: (item.category as Category) ?? "other",
             size: item.size ?? null,
+            shoe_size: item.shoe_size ?? null,
             image_url: item.image_url,
           }}
           existingImageUrl={getStorageUrl("items", item.image_url)}

--- a/src/app/(app)/items/[id]/page.tsx
+++ b/src/app/(app)/items/[id]/page.tsx
@@ -119,10 +119,14 @@ export default async function ItemDetailPage({
           <h1 className="text-xl font-bold leading-tight">
             {typedItem.title}
           </h1>
-          {(typedItem.category === "clothes" || typedItem.size) && (
+          {(typedItem.category !== "other" || typedItem.size || typedItem.shoe_size) && (
             <p className="mt-1 text-sm text-muted-foreground">
-              {typedItem.category === "clothes" ? "Kleidung" : "Sonstiges"}
+              {typedItem.category === "clothing" ? "Kleidung" :
+               typedItem.category === "shoes" ? "Schuhe" :
+               typedItem.category === "toys" ? "Spielzeug" :
+               typedItem.category === "outdoor_sports" ? "Draußen & Sport" : "Sonstiges"}
               {typedItem.size && ` · Größe ${typedItem.size}`}
+              {typedItem.shoe_size && ` · Größe ${typedItem.shoe_size}`}
             </p>
           )}
           <p className="mt-1 text-sm text-muted-foreground">

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -8,9 +8,9 @@ import type { ItemWithSeller } from "@/lib/types/database";
 export default async function HomePage({
   searchParams,
 }: {
-  searchParams: Promise<{ q?: string; pricing?: string; category?: string; size?: string }>;
+  searchParams: Promise<{ q?: string; pricing?: string; category?: string; size?: string; shoe_size?: string }>;
 }) {
-  const { q, pricing, category, size } = await searchParams;
+  const { q, pricing, category, size, shoe_size } = await searchParams;
   const supabase = await createClient();
 
   let query = supabase
@@ -43,10 +43,14 @@ export default async function HomePage({
     query = query.eq("size", size);
   }
 
+  if (shoe_size) {
+    query = query.eq("shoe_size", shoe_size);
+  }
+
   const { data: items } = await query.order("created_at", { ascending: false });
 
   const feed = (items ?? []) as unknown as ItemWithSeller[];
-  const hasFilters = !!(q || pricing || category || size);
+  const hasFilters = !!(q || pricing || category || size || shoe_size);
 
   return (
     <PullToRefresh>

--- a/src/components/item-card.tsx
+++ b/src/components/item-card.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { getStorageUrl, timeAgo, pricingLabel } from "@/lib/utils";
+import { CATEGORIES } from "@/lib/types/database";
 import type { ItemWithSeller } from "@/lib/types/database";
 
 export function ItemCard({ item }: { item: ItemWithSeller }) {
@@ -28,20 +29,26 @@ export function ItemCard({ item }: { item: ItemWithSeller }) {
           className="object-cover transition-transform group-hover:scale-105"
           sizes="(max-width: 640px) 50vw, (max-width: 1024px) 33vw, 25vw"
         />
-        <Badge
-          variant={item.pricing_type === "free" ? "default" : "secondary"}
-          className="absolute bottom-2 left-2"
-        >
-          {pricingLabel(item.pricing_type, item.pricing_detail)}
-        </Badge>
+        <div className="absolute bottom-2 left-2 flex gap-1">
+          <Badge
+            variant={item.pricing_type === "free" ? "default" : "secondary"}
+          >
+            {pricingLabel(item.pricing_type, item.pricing_detail)}
+          </Badge>
+          {item.category !== "other" && (
+            <Badge variant="outline" className="bg-background/80 backdrop-blur-sm">
+              {CATEGORIES.find((c) => c.slug === item.category)?.label}
+            </Badge>
+          )}
+        </div>
       </div>
 
       <div className="p-3">
         <h3 className="truncate font-medium leading-tight">
           {item.title}
-          {item.size && (
+          {(item.size || item.shoe_size) && (
             <span className="ml-1 text-xs font-normal text-muted-foreground">
-              · Gr. {item.size}
+              · Gr. {item.size || item.shoe_size}
             </span>
           )}
         </h3>

--- a/src/components/item-form.tsx
+++ b/src/components/item-form.tsx
@@ -17,7 +17,7 @@ import {
 import { ImageUpload } from "@/components/image-upload";
 import { toast } from "sonner";
 import type { PricingType, Category } from "@/lib/types/database";
-import { CLOTHING_SIZES } from "@/lib/types/database";
+import { CLOTHING_SIZES, CLOTHING_SIZE_LABELS, SHOE_SIZES, CATEGORIES } from "@/lib/types/database";
 
 type ItemFormProps = {
   mode: "create" | "edit";
@@ -29,6 +29,7 @@ type ItemFormProps = {
     pricing_detail: string | null;
     category: Category;
     size: string | null;
+    shoe_size: string | null;
     image_url: string;
   };
   existingImageUrl?: string;
@@ -52,6 +53,7 @@ export function ItemForm({ mode, initialData, existingImageUrl }: ItemFormProps)
     initialData?.category ?? "other"
   );
   const [size, setSize] = useState(initialData?.size ?? "");
+  const [shoeSize, setShoeSize] = useState(initialData?.shoe_size ?? "");
   const [imageFile, setImageFile] = useState<File | null>(null);
 
   function handleSubmit(e: React.FormEvent) {
@@ -77,8 +79,12 @@ export function ItemForm({ mode, initialData, existingImageUrl }: ItemFormProps)
       toast.error("Die Beschreibung darf maximal 1000 Zeichen lang sein.");
       return;
     }
-    if (category === "clothes" && !size) {
+    if (category === "clothing" && !size) {
       toast.error("Bitte wähle eine Größe für Kleidung aus.");
+      return;
+    }
+    if (category === "shoes" && !shoeSize) {
+      toast.error("Bitte wähle eine Schuhgröße aus.");
       return;
     }
 
@@ -133,7 +139,8 @@ export function ItemForm({ mode, initialData, existingImageUrl }: ItemFormProps)
             pricing_type: pricingType,
             pricing_detail: pricingType === "other" ? pricingDetail.trim() || null : null,
             category,
-            size: category === "clothes" ? size : null,
+            size: category === "clothing" ? size : null,
+            shoe_size: category === "shoes" ? shoeSize : null,
             image_url: storagePath,
             status: "available",
           });
@@ -178,7 +185,8 @@ export function ItemForm({ mode, initialData, existingImageUrl }: ItemFormProps)
               pricing_type: pricingType,
               pricing_detail: pricingType === "other" ? pricingDetail.trim() || null : null,
               category,
-              size: category === "clothes" ? size : null,
+              size: category === "clothing" ? size : null,
+              shoe_size: category === "shoes" ? shoeSize : null,
               image_url: storagePath,
             })
             .eq("id", initialData.id);
@@ -244,20 +252,24 @@ export function ItemForm({ mode, initialData, existingImageUrl }: ItemFormProps)
           onValueChange={(val) => {
             const next = val as Category;
             setCategory(next);
-            if (next !== "clothes") setSize("");
+            if (next !== "clothing") setSize("");
+            if (next !== "shoes") setShoeSize("");
           }}
         >
           <SelectTrigger>
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="clothes">Kleidung</SelectItem>
-            <SelectItem value="other">Sonstiges</SelectItem>
+            {CATEGORIES.map((c) => (
+              <SelectItem key={c.slug} value={c.slug}>
+                {c.label}
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </div>
 
-      {category === "clothes" && (
+      {category === "clothing" && (
         <div className="space-y-2">
           <Label>Größe</Label>
           <Select value={size} onValueChange={setSize}>
@@ -266,6 +278,24 @@ export function ItemForm({ mode, initialData, existingImageUrl }: ItemFormProps)
             </SelectTrigger>
             <SelectContent>
               {CLOTHING_SIZES.map((s) => (
+                <SelectItem key={s} value={s}>
+                  {CLOTHING_SIZE_LABELS[s] ?? s}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {category === "shoes" && (
+        <div className="space-y-2">
+          <Label>Schuhgröße</Label>
+          <Select value={shoeSize} onValueChange={setShoeSize}>
+            <SelectTrigger>
+              <SelectValue placeholder="Schuhgröße wählen…" />
+            </SelectTrigger>
+            <SelectContent>
+              {SHOE_SIZES.map((s) => (
                 <SelectItem key={s} value={s}>
                   {s}
                 </SelectItem>

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+}

--- a/src/lib/types/database.ts
+++ b/src/lib/types/database.ts
@@ -25,12 +25,51 @@ export type PricingType = "free" | "lending" | "other";
 
 export type ItemStatus = "available" | "reserved";
 
-export type Category = "clothes" | "other";
+export type Category = "clothing" | "shoes" | "toys" | "outdoor_sports" | "other";
+
+export const CATEGORIES: { slug: Category; label: string }[] = [
+  { slug: "clothing", label: "Kleidung" },
+  { slug: "shoes", label: "Schuhe" },
+  { slug: "toys", label: "Spielzeug" },
+  { slug: "outdoor_sports", label: "Draußen & Sport" },
+  { slug: "other", label: "Sonstiges" },
+];
 
 export const CLOTHING_SIZES = [
   "50", "56", "62", "68", "74", "80", "86", "92", "98",
   "104", "110", "116", "122", "128", "134", "140", "146",
   "152", "158", "164", "170", "176",
+] as const;
+
+export const CLOTHING_SIZE_LABELS: Record<string, string> = {
+  "50": "50 (0–1 Mon.)",
+  "56": "56 (0–3 Mon.)",
+  "62": "62 (3–6 Mon.)",
+  "68": "68 (6–9 Mon.)",
+  "74": "74 (9–12 Mon.)",
+  "80": "80 (12–18 Mon.)",
+  "86": "86 (18–24 Mon.)",
+  "92": "92 (ca. 2 J.)",
+  "98": "98 (ca. 3 J.)",
+  "104": "104 (ca. 4 J.)",
+  "110": "110 (ca. 5 J.)",
+  "116": "116 (ca. 6 J.)",
+  "122": "122 (ca. 7 J.)",
+  "128": "128 (ca. 8 J.)",
+  "134": "134 (ca. 9 J.)",
+  "140": "140 (ca. 10 J.)",
+  "146": "146 (ca. 11 J.)",
+  "152": "152 (ca. 12 J.)",
+  "158": "158 (ca. 13 J.)",
+  "164": "164 (ca. 14 J.)",
+  "170": "170 (ca. 15 J.)",
+  "176": "176 (ca. 16 J.)",
+};
+
+export const SHOE_SIZES = [
+  "16", "17", "18", "19", "20", "21", "22", "23", "24", "25",
+  "26", "27", "28", "29", "30", "31", "32", "33", "34", "35",
+  "36", "37", "38", "39", "40",
 ] as const;
 
 export type Item = {
@@ -42,6 +81,7 @@ export type Item = {
   pricing_detail: string | null;
   category: Category;
   size: string | null;
+  shoe_size: string | null;
   image_url: string;
   status: ItemStatus;
   created_at: string;


### PR DESCRIPTION
## Summary
- **5 categories**: Kleidung, Schuhe, Spielzeug, Draußen & Sport, Sonstiges (renamed `clothes` → `clothing`)
- **Shoe sizes**: New `shoe_size` column with EU sizes 16–40
- **Clothing size labels**: Age labels in UI (e.g. "92 (ca. 2 J.)")
- **Chip-based filters**: Replaced Select dropdowns with horizontal scrollable filter chips using shadcn Popover — active chips show value + × to clear, size chip only appears for clothing/shoes
- **Category badges**: Item cards show category label
- **Supabase migration**: Renamed `clothes` → `clothing`, added `shoe_size` column, added category index

## Files changed
- `src/lib/types/database.ts` — Category type (5 values), size constants, labels
- `src/components/search-filter.tsx` — Full rewrite to chip-based Popover filters
- `src/components/item-form.tsx` — 5-category Select, shoe size picker
- `src/components/item-card.tsx` — Category badge + shoe_size display
- `src/app/(app)/page.tsx` — shoe_size query filter
- `src/app/(app)/items/[id]/page.tsx` — New category labels
- `src/app/(app)/items/[id]/edit/page.tsx` — Pass shoe_size to form
- `src/components/ui/popover.tsx` — New shadcn component
- `docs/DATABASE.md` + `docs/SEARCH_FEATURE.md` — Updated

## Test plan
- [ ] Create an item in each of the 5 categories — correct form fields shown
- [ ] Clothing item: size picker with age labels appears
- [ ] Shoes item: shoe size picker appears
- [ ] Filter chips: category, size (conditional), pricing all work
- [ ] Active chip shows selected value + clears on × tap
- [ ] Existing items display correctly after `clothes` → `clothing` rename
- [ ] Mobile: chips scroll horizontally, popovers don't overflow
- [ ] `pnpm build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)